### PR TITLE
Fix `arc` mod for x86_64

### DIFF
--- a/cidre/src/arc.rs
+++ b/cidre/src/arc.rs
@@ -186,7 +186,12 @@ pub fn rar_retain_option<T: objc::Obj>(id: Option<Rar<T>>) -> Option<R<T>> {
 
     unsafe {
         // see comments in rar_retain
+        #[cfg(target_arch = "aarch64")]
         asm!("mov x29, x29");
+
+        #[cfg(target_arch = "x86_64")]
+        asm!("mov rax, rdi");
+
         std::mem::transmute(objc::objc_retainAutoreleasedReturnValue(
             std::mem::transmute(id),
         ))
@@ -204,7 +209,12 @@ pub fn rar_retain<T: objc::Obj>(id: Rar<T>) -> R<T> {
         // but benchmarks show that on macos it is not a case yet
         // (see alloc_with_ar_retain bench).
         // Need to check on iOS.
+        #[cfg(target_arch = "aarch64")]
         asm!("mov x29, x29");
+        
+        #[cfg(target_arch = "x86_64")]
+        asm!("mov rax, rdi");
+
         std::mem::transmute(objc::objc_retainAutoreleasedReturnValue(
             std::mem::transmute(id),
         ))


### PR DESCRIPTION
reference: https://stackoverflow.com/a/74067363

with this change, `cidre` should now compile on `x86_64-apple-darwin` 

![CleanShot 2023-12-02 at 07 04 38](https://github.com/yury/cidre/assets/12202757/4b683946-864e-4390-a340-603638cc745a)
