### PR TITLE
feat: add apis for reading videos

### DIFF
--- a/cidre/src/av/asset/track.rs
+++ b/cidre/src/av/asset/track.rs
@@ -48,6 +48,12 @@ impl Track {
     pub fn has_media_characterisitc(&self, val: av::MediaCharacteristic) -> bool;
 }
 
+/// AVAssetTrackPropertiesForTemporalInformation
+impl Track {
+    #[objc::msg_send(timeRange)]
+    pub fn time_range(&self) -> cm::TimeRange;
+}
+
 /// AVAssetTrackPropertiesForVisualCharacteristic
 impl Track {
     #[objc::msg_send(naturalSize)]

--- a/cidre/src/cv/pixel_buffer.rs
+++ b/cidre/src/cv/pixel_buffer.rs
@@ -55,6 +55,12 @@ impl PixelBuf {
         unsafe { CVPixelBufferGetHeightOfPlane(self, plane_index) }
     }
 
+    #[doc(alias = "CVPixelBufferGetBaseAddressOfPlane")]
+    #[inline]
+    pub fn plane_base_address(&self, plane_index: usize) -> *const u8 {
+        unsafe { CVPixelBufferGetBaseAddressOfPlane(self, plane_index) }
+    }
+
     /// ```
     /// use cidre::{cv, cg};
     ///
@@ -659,6 +665,7 @@ extern "C-unwind" {
     fn CVPixelBufferGetPlaneCount(pixel_buffer: &PixelBuf) -> usize;
     fn CVPixelBufferGetWidthOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> usize;
     fn CVPixelBufferGetHeightOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> usize;
+    fn CVPixelBufferGetBaseAddressOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> *const u8;
 
     fn CVPixelBufferLockBaseAddress(pixel_buffer: &PixelBuf, lock_flags: LockFlags) -> cv::Return;
     fn CVPixelBufferUnlockBaseAddress(pixel_buffer: &PixelBuf, lock_flags: LockFlags)

--- a/cidre/src/cv/pixel_buffer.rs
+++ b/cidre/src/cv/pixel_buffer.rs
@@ -61,6 +61,12 @@ impl PixelBuf {
         unsafe { CVPixelBufferGetBaseAddressOfPlane(self, plane_index) }
     }
 
+    #[doc(alias = "CVPixelBufferGetBytesPerRowOfPlane")]
+    #[inline]
+    pub fn plane_bytes_per_row(&self, plane_index: usize) -> usize {
+        unsafe { CVPixelBufferGetBytesPerRowOfPlane(self, plane_index) }
+    }
+
     /// ```
     /// use cidre::{cv, cg};
     ///
@@ -666,6 +672,7 @@ extern "C-unwind" {
     fn CVPixelBufferGetWidthOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> usize;
     fn CVPixelBufferGetHeightOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> usize;
     fn CVPixelBufferGetBaseAddressOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> *const u8;
+    fn CVPixelBufferGetBytesPerRowOfPlane(pixel_buffer: &PixelBuf, plane_index: usize) -> usize;
 
     fn CVPixelBufferLockBaseAddress(pixel_buffer: &PixelBuf, lock_flags: LockFlags) -> cv::Return;
     fn CVPixelBufferUnlockBaseAddress(pixel_buffer: &PixelBuf, lock_flags: LockFlags)


### PR DESCRIPTION
### What does this PR do?
This PR adds support for some AV and CV APIs to help decoding video frames. The APIs added are
- AVAssetTrack.timeRange : https://developer.apple.com/documentation/avfoundation/avpartialasyncproperty/timerange
- CVPixelBufferGetBaseAddressOfPlane: https://developer.apple.com/documentation/corevideo/cvpixelbuffergetbaseaddressofplane(_:_:)
- CVPixelBufferGetBytesPerRowOfPlane: https://developer.apple.com/documentation/corevideo/cvpixelbuffergetbytesperrowofplane(_:_:)