### PR TITLE
chore: allow to build and run on fresh mac without apple tooling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777086717,
+        "narHash": "sha256-vEl3cGHRxEFdVNuP9PbrhAWnmU98aPOLGy9/1JXzSuM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3be56bd430bfd65d3c468a50626c3a601c7dee03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "Minimial viable version of shell to build MacOs targets without XCode/CLT installed";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      system = "aarch64-darwin";
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ rust-overlay.overlays.default ];
+      };
+      rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      macosDeploymentTarget = "15";
+      appleSdk = pkgs."apple-sdk_${macosDeploymentTarget}";
+      sdkRoot = "${appleSdk}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
+      llvmVersion = "19";
+      llvmPackages = pkgs."llvmPackages_${llvmVersion}";
+      clang = llvmPackages.clang-unwrapped;
+      clangResourceDir = "${clang.lib}/lib/clang/${llvmVersion}";
+      compilerRt = llvmPackages.compiler-rt-libc;
+      lld = llvmPackages.lld;
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          rustToolchain
+          rust-analyzer
+          pkg-config
+          clang
+          lld
+          appleSdk
+          darwin.cctools
+          libiconv
+        ];
+        MACOSX_DEPLOYMENT_TARGET = "${macosDeploymentTarget}.0";
+        RUSTFLAGS = "-C link-arg=-isysroot -C link-arg=${sdkRoot} -C link-arg=-L${compilerRt}/lib/darwin -C link-arg=-mmacosx-version-min=${macosDeploymentTarget}.0 -C link-arg=-fuse-ld=${lld}/bin/ld64.lld";
+        SDKROOT = sdkRoot;
+        shellHook = ''
+          export DEVELOPER_DIR="${appleSdk}"; # something overrides it on activation, so set here
+          export CC="''${CIDRE_CC:-${clang}/bin/clang}"
+          export CXX="''${CIDRE_CXX:-${clang}/bin/clang++}"
+          export AR="''${CIDRE_AR:-${pkgs.darwin.cctools}/bin/ar}"
+          export CFLAGS="''${CIDRE_CFLAGS:--resource-dir ${clangResourceDir} -isysroot $SDKROOT -mmacosx-version-min=${macosDeploymentTarget}.0}"
+          export CXXFLAGS="''${CIDRE_CXXFLAGS:-$CFLAGS}"
+          export CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER="$CC"
+        '';
+      };
+    };
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rust-src", "rustfmt"]
+targets = ["aarch64-apple-darwin"]


### PR DESCRIPTION

Lowering entry to develop for mac with deep integration with apple api to one line `nix develop`.

LLM assisted, but reviewed, guided and cleaned by me.
