### PR TITLE
Handle missing NSError out parameters

### DIFF
--- a/cidre/src/ns/error.rs
+++ b/cidre/src/ns/error.rs
@@ -19,7 +19,11 @@ where
     if f(&mut err) {
         Ok(())
     } else {
-        unsafe { Err(err.unwrap_unchecked()) }
+        // Cocoa NSError-by-reference APIs use the BOOL/nil return value as the
+        // success signal; the NSError pointer is detail, not the condition.
+        // Avoid unwrap_unchecked: a framework may report failure without
+        // populating the out-param, and that must not become UB.
+        Err(err.expect("Objective-C API returned false without NSError"))
     }
 }
 
@@ -28,7 +32,9 @@ where
     F: FnOnce(*mut Option<&'ear ns::Error>) -> Option<R>,
 {
     let mut err = None;
-    f(&mut err).ok_or_else(|| unsafe { err.unwrap_unchecked() })
+    // See if_false: nil is the failure signal, but the NSError out-param can
+    // still be absent on framework edge cases.
+    f(&mut err).ok_or_else(|| err.expect("Objective-C API returned nil without NSError"))
 }
 
 pub fn if_err<'ear>(f: impl FnOnce(*mut Option<&'ear ns::Error>)) -> ns::Result<'ear> {


### PR DESCRIPTION
## Summary

- Replace unchecked unwraps in NSError out-parameter helpers with checked handling
- Keep failure reporting explicit when Objective-C APIs return false or nil without populating NSError
- Document why the return value is the authoritative success signal for Cocoa NSError-by-reference APIs

## Rationale

Cocoa APIs that take an NSError out-parameter report success or failure through the method return value. The NSError pointer carries diagnostic detail and may be absent on framework edge cases. Using unwrap_unchecked on that pointer can turn a recoverable framework failure into undefined behavior or process abort.

## Validation

- rustfmt on cidre/src/ns/error.rs
- cargo check -p cidre
